### PR TITLE
URI for making urls

### DIFF
--- a/lib/kickfire/company.rb
+++ b/lib/kickfire/company.rb
@@ -25,7 +25,10 @@ module Kickfire
         end
       end
 
-      response = HTTParty.get("#{BASE_URL}#{BASE_QUERY}?#{URI.encode_www_form({ip: ip, key: api_key})}")
+      uri = URI("#{BASE_URL}#{BASE_QUERY}")
+      params = { ip: ip, key: api_key }
+      uri.query = URI.encode_www_form(params)
+      response = ::HTTParty.get(uri)
 
       if !response
         raise Kickfire::Error.new('No data returned from Kickfire')


### PR DESCRIPTION
Erwin noticed that we were building the urls manually instead of using methods URI already gives us. This should be more secure, better formed, and provide better messaging when malformed.

Not bumping the version number as this is non breaking and minor improvement.